### PR TITLE
Add 02-16-2021 meeting minutes

### DIFF
--- a/minutes/02-16-2021.md
+++ b/minutes/02-16-2021.md
@@ -1,0 +1,21 @@
+# Tern Community Meeting Minutes, 02-16-2021
+
+## Attending
+* Rose Judge (VMware)
+* Alexander Mazuruk (Samsung)
+
+## Agenda
+* Discussion on open PRs
+* Release 2.4.0
+* Other?
+
+# Minutes
+
+### Discussion on open PRs
+* Rose has fully tested Alexander's open [PR](https://github.com/tern-tools/tern/pull/847) and is satisfied with functionality. She will merge this week.
+
+### Release 2.4.0
+* Due to a rather large [bug](https://github.com/tern-tools/tern/issues/874) we will likely cut a release this week to pick up a fix. Will not be full 3.0.0 release but, rather, a "mini-release"
+
+### Tern Usage Updates
+* Alexander is working on integrating Tern in to ONAP's CI/CD pipeline in GitLab. Up until now Tern was scanning ONAP images locally. 


### PR DESCRIPTION
This commit adds the February 16, 2021 meeting minutes to the
repository.

Signed-off-by: Rose Judge <rjudge@vmware.com>