### PR TITLE
Add 05-25-2021 meeting minutes

### DIFF
--- a/minutes/05-25-2021.md
+++ b/minutes/05-25-2021.md
@@ -1,0 +1,20 @@
+# Tern Community Meeting Minutes, 05-25-2021
+
+## Attending
+* Rose Judge (VMware)
+* Nisha Kumar (VMware)
+* Mukul Taneja (VMware)
+
+## Agenda
+* PRs:
+    * [Replaces image aliases in Dockerfile](https://github.com/tern-tools/tern/pull/963)
+
+# Minutes
+
+### PRs
+* Replaces image aliases in Dockerfile
+    * Share-screen discussion
+    * Flow of multistage dockerfiles:
+        * `execute_dockerfile()` → `for each dockerfile it analyzes them as a single, separate, dockerfile.
+    * Mukul will update the PR and Rose and Nisha can review next week.
+


### PR DESCRIPTION
This commit adds the May 25, 2021 meeting minutes to the repository.

Signed-off-by: Rose Judge <rjudge@vmware.com>